### PR TITLE
convert graph from string to bytes for python 3 compatibility

### DIFF
--- a/dojobber/dojobber.py
+++ b/dojobber/dojobber.py
@@ -407,8 +407,8 @@ class DoJobber(object):
             command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            )
-        stdout, _ = proc.communicate(dot.write(self.graph))
+        )
+        stdout, _ = proc.communicate(dot.write(self.graph).encode())
 
         if proc.returncode != 0:
             raise RuntimeError(


### PR DESCRIPTION
On Python 3.5 I had to convert this string to bytes in order for memoryview to be able to handle it.